### PR TITLE
test: add formatCR unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /fonts
+
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "encounterbuilder",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/adversaryData.test.js
+++ b/tests/adversaryData.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatCR } from '../script/adversaryData.js';
+
+test('formatCR formats fractional and whole CR values', () => {
+  assert.strictEqual(formatCR(0.5), '1/2');
+  assert.strictEqual(formatCR(0.75), '3/4');
+  assert.strictEqual(formatCR(2), '2');
+});


### PR DESCRIPTION
## Summary
- add Node test suite for `formatCR`
- configure Node's built-in test runner for CI
- ignore `node_modules`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb43c7f08833089a2210c7e8bbd4c