### PR TITLE
Handle optional search field in filters

### DIFF
--- a/script/adversaryUI.js
+++ b/script/adversaryUI.js
@@ -222,9 +222,10 @@ function toggleFilter(button) {
 
 // Function to update filters dynamically
 function updateFilters() {
-  filterObject.search =
-    document.getElementById('search-adversary').value.trim().toLowerCase() ||
-    null;
+  const searchEl = document.getElementById('search-adversary');
+  filterObject.search = searchEl
+    ? searchEl.value.trim().toLowerCase()
+    : null;
   filterObject.cr = document.getElementById('filter-cr').value || null;
   filterObject.habitat =
     document.getElementById('filter-habitat').value || null;


### PR DESCRIPTION
## Summary
- Safely handle missing `search-adversary` element when updating filters

## Testing
- `node <<'NODE'
const filterObject = {search: null, cr: null, habitat: null, type: null, group: null};
function updateFilters() {
  const searchEl = document.getElementById('search-adversary');
  filterObject.search = searchEl
    ? searchEl.value.trim().toLowerCase()
    : null;
  filterObject.cr = document.getElementById('filter-cr').value || null;
}
const document = {
  elements: {
    'search-adversary': {value: ' Goblin '},
    'filter-cr': {value: '1'},
  },
  getElementById(id) { return this.elements[id] || null; }
};
global.document = document;
updateFilters();
console.log(filterObject);
NODE`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb41e02e083308c7c89546a0129eb