### PR TITLE
Replace deprecated border-l-0 classes with border-start-0

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
                     APL
                   </div>
                   <div
-                    class="stat-value border border-secondary border-3 border-l-0"
+                    class="stat-value border border-secondary border-3 border-start-0"
                     style="border-left: 0px"
                   >
                     <span
@@ -455,7 +455,7 @@
                     Budget
                   </div>
                   <div
-                    class="stat-value border border-secondary border-3 border-l-0"
+                    class="stat-value border border-secondary border-3 border-start-0"
                     style="border-left: 0px"
                   >
                     <span id="xp-budget" class="mx-4 my-1 text-secondary"
@@ -475,7 +475,7 @@
                     Encounter
                   </div>
                   <div
-                    class="stat-value border border-secondary border-3 border-l-0"
+                    class="stat-value border border-secondary border-3 border-start-0"
                     style="border-left: 0px"
                   >
                     <span id="bad-guys-xp" class="mx-4 my-1 text-secondary"
@@ -496,7 +496,7 @@
                     Balance
                   </div>
                   <div
-                    class="stat-value border border-secondary border-3 border-l-0"
+                    class="stat-value border border-secondary border-3 border-start-0"
                     style="border-left: 0px"
                   >
                     <span id="encounter-balance" class="mx-4 my-1">0</span>

--- a/script/adversaryManager.js
+++ b/script/adversaryManager.js
@@ -195,7 +195,7 @@ function updateEncounterBalance() {
   balanceElement.textContent = balance.toLocaleString();
   balanceElement.className = `mx-4 my-1 ${textColor}`;
   labelElement.className = `stat-label px-3 py-2 text-white ${colorClass}`;
-  valueContainer.className = `stat-value border border-3 border-l-0 ${borderClass}`;
+  valueContainer.className = `stat-value border border-3 border-start-0 ${borderClass}`;
 }
 
 // Utility function to capitalize words and replace underscores


### PR DESCRIPTION
## Summary
- use `border-start-0` in stat value sections of index.html
- update `adversaryManager` to generate `border-start-0`

## Testing
- `python - <<'PY'
import re, pathlib
html = pathlib.Path('index.html').read_text()
ids = ['average-party-level','xp-budget','bad-guys-xp','encounter-balance']
for id in ids:
    pattern = re.compile(rf'<span[^>]*id="{id}"[^>]*>', re.MULTILINE)
    match = pattern.search(html)
    if match:
        before = html[:match.start()]
        div_start = before.rfind('<div')
        div_end = before.find('>', div_start) + 1
        div_tag = before[div_start:div_end]
        print(id, 'border-start-0' in div_tag, div_tag.strip())
    else:
        print(id, 'not found')
PY`
- `node tools/validateJSON.js > /tmp/node.log 2>&1; tail -n 20 /tmp/node.log`

------
https://chatgpt.com/codex/tasks/task_e_68adb40cba8483309787c9888a60a976